### PR TITLE
Add zero input test for formatBytes

### DIFF
--- a/tests/utils.format.test.js
+++ b/tests/utils.format.test.js
@@ -144,6 +144,10 @@ describe('formatBytes', () => {
         expect(formatBytes(10485760, 3)).toBe('10.000 MB');
     });
 
+    it('returns "0 Bytes" for zero input', () => {
+        expect(formatBytes(0)).toBe('0 Bytes');
+    });
+
     it('returns empty string for invalid inputs', () => {
         expect(formatBytes('invalid')).toBe('');
         expect(formatBytes(null)).toBe('');


### PR DESCRIPTION
## Summary
- cover the case where `formatBytes` is passed `0`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f67e32df08327aebd90210f2e613f